### PR TITLE
Depth check improvements

### DIFF
--- a/lib/rules/max-depth.js
+++ b/lib/rules/max-depth.js
@@ -68,6 +68,28 @@ module.exports = {
             },
             additionalProperties: false,
           },
+          {
+            type: 'object',
+            properties: {
+              array: {
+                type: 'object',
+                properties: {
+                  max: {
+                    type: 'number',
+                  },
+                },
+              },
+              object: {
+                type: 'object',
+                properties: {
+                  max: {
+                    type: 'number',
+                  },
+                },
+              },
+            },
+            additionalProperties: false,
+          },
         ],
       },
       {
@@ -97,6 +119,7 @@ module.exports = {
     let normalizedOptions = {
       VariableDeclarator: { array: true, object: true },
       AssignmentExpression: { array: true, object: true },
+      AssignmentPattern: { array: true, object: true },
     };
 
     //--------------------------------------------------------------------------
@@ -131,14 +154,44 @@ module.exports = {
       });
     }
 
-    function findDestructuringDepth(sourceNode) {
-      if (!sourceNode || sourceNode.type !== 'ObjectPattern') {
-        return 0;
+    function findDestructuringDepth(sourceNode, curDepth = 0) {
+      let maxDepth = 0;
+      let node = sourceNode;
+
+      if (!node.properties || node.properties.length < 1) {
+        return curDepth;
       }
 
-      return (
-        1 + Math.max(...sourceNode.properties.map((n) => (n.type === 'Property' ? findDestructuringDepth(n.value) : 0)))
-      );
+      // recursively check all child properties for depth violations
+      node.properties.forEach(prop => {
+        if (prop.value) {
+          // regular nested object destructuring: `const { prop: { child } } = ...`
+          if (prop.value.type === 'ObjectPattern') {
+            const nodeDepth = findDestructuringDepth(
+                prop.value,
+                curDepth + 1
+            );
+            if (nodeDepth > maxDepth) {
+              maxDepth = nodeDepth;
+            }
+          } else if (
+              node.type === 'ObjectPattern' &&
+              prop.value.type === 'AssignmentPattern' &&
+              prop.value.left.type === 'ObjectPattern'
+          ) {
+            // object destructuring with assignment: `const { prop: { child } = {} } = ...`
+            const nodeDepth = findDestructuringDepth(
+                prop.value.left, // note: this is a subtle difference from the code above, so don't combine these cases
+                curDepth + 1
+            );
+            if (nodeDepth > maxDepth) {
+              maxDepth = nodeDepth;
+            }
+          }
+        }
+      })
+
+      return Math.max(maxDepth, curDepth);
     }
 
     /**
@@ -155,7 +208,7 @@ module.exports = {
     function performCheck(leftNode, rightNode, reportNode) {
       if (!leftNode.properties) return;
       if (shouldCheck(reportNode.type, 'object')) {
-        const depth = findDestructuringDepth(leftNode) - 1;
+        const depth = findDestructuringDepth(leftNode);
 
         if (depth > MAX_DEPTH) {
           report(reportNode, depth);

--- a/tests/lib/rules/max-depth.js
+++ b/tests/lib/rules/max-depth.js
@@ -28,6 +28,16 @@ ruleTester.run('prefer-destructuring', rule, {
       options: [{ object: true }],
       parserOptions: { ecmaVersion: 9 },
     },
+    {
+      code: 'const { bar = {} } = {}',
+      options: [{ object: true }],
+      parserOptions: { ecmaVersion: 9 },
+    },
+    {
+      code: 'const { foo: { bar } } = {}',
+      options: [{ object: { max: 1 } }],
+      parserOptions: { ecmaVersion: 9 },
+    },
   ],
 
   invalid: [
@@ -52,6 +62,43 @@ ruleTester.run('prefer-destructuring', rule, {
           type: 'VariableDeclarator',
         },
       ],
+    },
+    {
+      code: 'const { foo: { bar } = {}, baz } = {}',
+      output: null,
+      errors: [
+          {
+              messageId: 'tooDeeply',
+              data: { depth: 1, maxDepth: 0 },
+              type: 'VariableDeclarator',
+          },
+      ],
+      parserOptions: { ecmaVersion: 9 },
+    },
+    {
+      code: 'const { first, second: { third } = {} } = {}',
+      output: null,
+      errors: [
+          {
+              messageId: 'tooDeeply',
+              data: { depth: 1, maxDepth: 0 },
+              type: 'VariableDeclarator',
+          },
+      ],
+      parserOptions: { ecmaVersion: 9 },
+    },
+    {
+      code: 'const { one, first: { second: { third } } = {} } = {}',
+      output: null,
+      options: [{ object: { max: 1 } }],
+      errors: [
+          {
+              messageId: 'tooDeeply',
+              data: { depth: 2, maxDepth: 1 },
+              type: 'VariableDeclarator',
+          },
+      ],
+      parserOptions: { ecmaVersion: 9 },
     },
   ],
 });


### PR DESCRIPTION
Hello and thank you for making this eslint plugin. It has been helpful in automating destructuring code conventions for us. While implementing it, I found some problems. It did not work for us in the following scenarios:

When the destructured property was not the first in the object declaration:
```
const { one, two: { three } } = {}
```

When the destructured property had a default value assigned:
```
const { one: { two } = {} } = {}
```

While adding tests I also noticed that the `{object: { max: 1 } }` option format was not accepted, so I added that to the schema as well.

I'm contributing back my fixes for these. I hope they will be helpful to others. 

Let me know if there's anything you'd like to discuss or change about it.